### PR TITLE
FIX: Incorrect taxonomy in the "behavioral-traits" example

### DIFF
--- a/samples/cloud natural language api/document classification/behavioral-traits.py
+++ b/samples/cloud natural language api/document classification/behavioral-traits.py
@@ -4,7 +4,7 @@ from expertai.nlapi.cloud.client import ExpertAiClient
 client = ExpertAiClient()
 
 text = "Michael Jordan was one of the best basketball players of all time. Scoring was Jordan's stand-out skill, but he still holds a defensive NBA record, with eight steals in a half."
-taxonomy = 'iptc'
+taxonomy = 'behavioral-traits'
 language= 'en'
 
 output = client.classification(body={"document": {"text": text}}, params={'taxonomy': taxonomy, 'language': language})


### PR DESCRIPTION
The behavioural-traits example appears to have the incorrect taxonomy - perhaps an error of copy-paste? Unless I'm completely wrong and one can get behavioural traits from IPTC.